### PR TITLE
Fix username property in example admin identity

### DIFF
--- a/configuration/Magium/Magento/Identities/Admin.php
+++ b/configuration/Magium/Magento/Identities/Admin.php
@@ -2,5 +2,5 @@
 
 /* @var $this \Magium\Magento\Identities\Admin */
 
-$this->username = 'admin';
+$this->account = 'admin';
 $this->password = 'Password1';


### PR DESCRIPTION
I noticed that changing the username did not have any effect. This is because the property "username" does not exist and "admin" just happens to be the default value. The correct property name is "account".
